### PR TITLE
Append Toggle Shortcuts for Preview and Studio Mode

### DIFF
--- a/src/shortcutsPortal.cpp
+++ b/src/shortcutsPortal.cpp
@@ -20,6 +20,7 @@
 
 #include <obs-frontend-api.h>
 #include <obs-hotkey.h>
+#include <obs.h>
 
 #include <QMessageBox>
 
@@ -170,18 +171,20 @@ void ShortcutsPortal::createShortcuts()
     });
 
     // https://github.com/obsproject/obs-studio/pull/12580
-    // OBS API currently broken for this function. Will be fixed with related merge request. Syntax remains correct.
+    /* Update release version number and uncomment when related request is merged.
 
-    createShortcut("_toggle_preview", "Toggle Preview", [](bool pressed) {
-        if (!pressed)
-            return;
+    if (QVersionNumber::fromString(obs_get_version_string()) >= QVersionNumber(32, 1, 0))
+        createShortcut("_toggle_preview", "Toggle Preview", [](bool pressed) {
+            if (!pressed)
+                return;
 
-        if (obs_frontend_preview_enabled()) {
-            obs_frontend_set_preview_enabled(false);
-        } else {
-            obs_frontend_set_preview_enabled(true);
-        }
-    });
+            if (obs_frontend_preview_enabled()) {
+                obs_frontend_set_preview_enabled(false);
+            } else {
+                obs_frontend_set_preview_enabled(true);
+            }
+        });
+    */
 
     createShortcut("_toggle_studio_mode", "Toggle Studio Mode", [](bool pressed) {
         if (!pressed)


### PR DESCRIPTION
Related to #6, I went ahead and added and tested toggle shortcuts for Preview and Studio Mode, in order to increase feature parity with OBS' built-in hotkeys.

Currently, the preview toggle specifically *will not* work as expected in current versions of OBS. This is a bug in OBS' Frontend API which [this pull request](https://github.com/obsproject/obs-studio/pull/12580) handles. Given that the pull request doesn't change the function call and has been approved, there should be no changes necessary for the preview toggle to work when the request is merged.

Whether the specific shortcut should be commented out for now or be left in is something that should be decided upon.