### PR TITLE
docs: Add build dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ On Gnome its on Settings -> Apps -> OBS Studio -> Global Shortcuts
 Uh go look at the OBS plugin template docs:
 https://github.com/obsproject/obs-plugintemplate/wiki/
 
+Requires the `Qt6WaylandClient` and `Qt6GuiPrivate` development files, which should also pull in `Qt6Base`.
 


### PR DESCRIPTION
Noticed while building [my plugin package for Fedora](https://github.com/mihawk90/obs-studio-plugins.spec/blob/main/obs-studio-plugin-wayland-hotkeys/obs-studio-plugin-wayland-hotkeys.spec). These were the only two I had to add.