### PR TITLE
added audio toggle functionality

### DIFF
--- a/src/shortcutsPortal.cpp
+++ b/src/shortcutsPortal.cpp
@@ -151,6 +151,31 @@ static bool hasAudioCapabilities(obs_source_t* source)
     return (flags & OBS_SOURCE_AUDIO) != 0;
 }
 
+static bool hasVideoCapabilities(obs_source_t* source)
+{
+    uint32_t flags = obs_source_get_output_flags(source);
+    return (flags & OBS_SOURCE_VIDEO) != 0;
+}
+
+static void toggleVisibility(obs_source_t* source)
+{
+    obs_source_t* currentSceneSource = obs_frontend_get_current_scene();
+    if (!currentSceneSource)
+        return;
+
+    obs_scene_t* currentScene = obs_scene_from_source(currentSceneSource);
+    obs_source_release(currentSceneSource);
+    if (!currentScene)
+        return;
+
+    const char* sourceName = obs_source_get_name(source);
+    obs_sceneitem_t* item = obs_scene_find_source_recursive(currentScene, sourceName);
+    if (!item)
+        return;
+
+    obs_sceneitem_set_visible(item, !obs_sceneitem_visible(item));
+}
+
 void ShortcutsPortal::createOBSShortcut(obs_hotkey_id id, obs_hotkey_t* hotkey)
 {
     auto name = getHotkeyNameAndDesc(hotkey);
@@ -262,7 +287,9 @@ void ShortcutsPortal::createShortcuts()
             auto* portal = (ShortcutsPortal*)data;
             auto weakSource = std::shared_ptr<obs_weak_source_t>(
                 obs_source_get_weak_source(source),
-                [](obs_weak_source_t* ws) { obs_weak_source_release(ws); }
+                [](obs_weak_source_t* ws) {
+                    obs_weak_source_release(ws);
+                }
             );
 
             portal->createShortcut(
@@ -277,6 +304,47 @@ void ShortcutsPortal::createShortcuts()
                         obs_source_set_muted(src, !obs_source_muted(src));
                         obs_source_release(src);
                     }
+                }
+            );
+            return true;
+        },
+        this
+    );
+
+    // Create video/image source visibility toggles for all sources
+    obs_enum_sources(
+        [](void* data, obs_source_t* source) {
+            if (!hasVideoCapabilities(source)) {
+                return true;
+            }
+
+            QString sourceName = obs_source_get_name(source);
+            QString safeSourceName = QString(sourceName).replace(" ", "_");
+            QString shortcutName = u"_toggle_visible.%1"_s.arg(safeSourceName);
+            QString description = u"Toggle Visible (%1)"_s.arg(sourceName);
+
+            auto* portal = (ShortcutsPortal*)data;
+            auto weakSource = std::shared_ptr<obs_weak_source_t>(
+                obs_source_get_weak_source(source),
+                [](obs_weak_source_t* ws) {
+                    obs_weak_source_release(ws);
+                }
+            );
+
+            portal->createShortcut(
+                shortcutName,
+                description,
+                [weakSource](bool pressed) {
+                    if (!pressed)
+                        return;
+
+                    obs_source_t* src = obs_weak_source_get_source(weakSource.get());
+                    if (!src)
+                        return;
+
+                    toggleVisibility(src);
+
+                    obs_source_release(src);
                 }
             );
             return true;
@@ -475,7 +543,7 @@ ShortcutsPortal::~ShortcutsPortal()
         GLOBAL_SHORTCUTS_INTERFACE,
         u"Deactivated"_s,
         this,
-        SLOT(onActivatedSignal(
+        SLOT(onDeactivatedSignal(
             QDBusObjectPath, QString, qulonglong, QVariantMap
         ))
     );

--- a/src/shortcutsPortal.cpp
+++ b/src/shortcutsPortal.cpp
@@ -145,6 +145,12 @@ static QPair<QString, QString> getHotkeyNameAndDesc(obs_hotkey_t* hotkey)
     return {name, description};
 };
 
+static bool hasAudioCapabilities(obs_source_t* source)
+{
+    uint32_t flags = obs_source_get_output_flags(source);
+    return (flags & OBS_SOURCE_AUDIO) != 0;
+}
+
 void ShortcutsPortal::createOBSShortcut(obs_hotkey_id id, obs_hotkey_t* hotkey)
 {
     auto name = getHotkeyNameAndDesc(hotkey);
@@ -240,6 +246,43 @@ void ShortcutsPortal::createShortcuts()
             obs_frontend_set_preview_program_mode(true);
         }
     });
+
+    // Create audio source mute toggles for all audio-enabled sources
+    obs_enum_sources(
+        [](void* data, obs_source_t* source) {
+            if (!hasAudioCapabilities(source)) {
+                return true;
+            }
+
+            QString sourceName = obs_source_get_name(source);
+            QString safeSourceName = sourceName.replace(" ", "_");
+            QString shortcutName = u"_toggle_mute.%1"_s.arg(safeSourceName);
+            QString description = u"Toggle Mute (%1)"_s.arg(sourceName);
+
+            auto* portal = (ShortcutsPortal*)data;
+            auto weakSource = std::shared_ptr<obs_weak_source_t>(
+                obs_source_get_weak_source(source),
+                [](obs_weak_source_t* ws) { obs_weak_source_release(ws); }
+            );
+
+            portal->createShortcut(
+                shortcutName,
+                description,
+                [weakSource](bool pressed) {
+                    if (!pressed)
+                        return;
+
+                    obs_source_t* src = obs_weak_source_get_source(weakSource.get());
+                    if (src) {
+                        obs_source_set_muted(src, !obs_source_muted(src));
+                        obs_source_release(src);
+                    }
+                }
+            );
+            return true;
+        },
+        this
+    );
 
     bindShortcuts();
 }

--- a/src/shortcutsPortal.cpp
+++ b/src/shortcutsPortal.cpp
@@ -145,18 +145,6 @@ static QPair<QString, QString> getHotkeyNameAndDesc(obs_hotkey_t* hotkey)
     return {name, description};
 };
 
-static bool hasAudioCapabilities(obs_source_t* source)
-{
-    uint32_t flags = obs_source_get_output_flags(source);
-    return (flags & OBS_SOURCE_AUDIO) != 0;
-}
-
-static bool hasVideoCapabilities(obs_source_t* source)
-{
-    uint32_t flags = obs_source_get_output_flags(source);
-    return (flags & OBS_SOURCE_VIDEO) != 0;
-}
-
 static void toggleVisibility(obs_source_t* source)
 {
     obs_source_t* currentSceneSource = obs_frontend_get_current_scene();
@@ -272,56 +260,18 @@ void ShortcutsPortal::createShortcuts()
         }
     });
 
-    // Create audio source mute toggles for all audio-enabled sources
+    // Create audio mute and video visibility toggles for all matching sources
     obs_enum_sources(
         [](void* data, obs_source_t* source) {
-            if (!hasAudioCapabilities(source)) {
+            uint32_t flags = obs_source_get_output_flags(source);
+            bool hasAudio = (flags & OBS_SOURCE_AUDIO) != 0;
+            bool hasVideo = (flags & OBS_SOURCE_VIDEO) != 0;
+
+            if (!hasAudio && !hasVideo) {
                 return true;
             }
-
-            QString sourceName = obs_source_get_name(source);
-            QString safeSourceName = sourceName.replace(" ", "_");
-            QString shortcutName = u"_toggle_mute.%1"_s.arg(safeSourceName);
-            QString description = u"Toggle Mute (%1)"_s.arg(sourceName);
-
-            auto* portal = (ShortcutsPortal*)data;
-            auto weakSource = std::shared_ptr<obs_weak_source_t>(
-                obs_source_get_weak_source(source),
-                [](obs_weak_source_t* ws) {
-                    obs_weak_source_release(ws);
-                }
-            );
-
-            portal->createShortcut(
-                shortcutName,
-                description,
-                [weakSource](bool pressed) {
-                    if (!pressed)
-                        return;
-
-                    obs_source_t* src = obs_weak_source_get_source(weakSource.get());
-                    if (src) {
-                        obs_source_set_muted(src, !obs_source_muted(src));
-                        obs_source_release(src);
-                    }
-                }
-            );
-            return true;
-        },
-        this
-    );
-
-    // Create video/image source visibility toggles for all sources
-    obs_enum_sources(
-        [](void* data, obs_source_t* source) {
-            if (!hasVideoCapabilities(source)) {
-                return true;
-            }
-
             QString sourceName = obs_source_get_name(source);
             QString safeSourceName = QString(sourceName).replace(" ", "_");
-            QString shortcutName = u"_toggle_visible.%1"_s.arg(safeSourceName);
-            QString description = u"Toggle Visible (%1)"_s.arg(sourceName);
 
             auto* portal = (ShortcutsPortal*)data;
             auto weakSource = std::shared_ptr<obs_weak_source_t>(
@@ -330,23 +280,46 @@ void ShortcutsPortal::createShortcuts()
                     obs_weak_source_release(ws);
                 }
             );
+            if (hasAudio) {
+                QString shortcutName = u"_toggle_mute.%1"_s.arg(safeSourceName);
+                QString description = u"Toggle Mute (%1)"_s.arg(sourceName);
 
-            portal->createShortcut(
-                shortcutName,
-                description,
-                [weakSource](bool pressed) {
-                    if (!pressed)
-                        return;
+                portal->createShortcut(
+                    shortcutName,
+                    description,
+                    [weakSource](bool pressed) {
+                        if (!pressed)
+                            return;
 
-                    obs_source_t* src = obs_weak_source_get_source(weakSource.get());
-                    if (!src)
-                        return;
+                        obs_source_t* src = obs_weak_source_get_source(weakSource.get());
+                        if (src) {
+                            obs_source_set_muted(src, !obs_source_muted(src));
+                            obs_source_release(src);
+                        }
+                    }
+                );
+            }
+            if (hasVideo) {
+                QString shortcutName = u"_toggle_visible.%1"_s.arg(safeSourceName);
+                QString description = u"Toggle Visible (%1)"_s.arg(sourceName);
 
-                    toggleVisibility(src);
+                portal->createShortcut(
+                    shortcutName,
+                    description,
+                    [weakSource](bool pressed) {
+                        if (!pressed)
+                            return;
 
-                    obs_source_release(src);
-                }
-            );
+                        obs_source_t* src = obs_weak_source_get_source(weakSource.get());
+                        if (!src)
+                            return;
+
+                        toggleVisibility(src);
+
+                        obs_source_release(src);
+                    }
+                );
+            }
             return true;
         },
         this


### PR DESCRIPTION
I needed a toggle functionality for streaming while im not in the main window, and since there already was the toggle option for other stuff I figured why not also extend it to all audio sources. I tested it locally with my obs on cachyos and it worked right out of the box. If anyone has any comments or Ideas about this I would appreciate it a lot. This is my first pull request to a open source Project ever so I dont know if I made some mistakes or was rude about the procedure, if yes please say so. 