### PR TITLE
Add a toggler for pausing/unpausing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Additionally, since KDE Plasma and GNOME do not allow binding multiple keybindin
 :_toggle_streaming -> Toggle Streaming
 :_toggle_studio_mode -> Toggle Studio Mode
 :_toggle_virtualcam -> Toggle Virtual Camera
+:_toggle_pause_unpause -> Toggle Pause/Unpause
 ```
 
 ## Configuring

--- a/src/shortcutsPortal.cpp
+++ b/src/shortcutsPortal.cpp
@@ -214,6 +214,17 @@ void ShortcutsPortal::createShortcuts()
         }
     });
 
+    createShortcut("_toggle_pause_unpause", "Toggle Pause/Unpause", [](bool pressed) {
+        if (!pressed)
+            return;
+
+        if (obs_frontend_recording_paused()) {
+            obs_frontend_recording_pause(false);
+        } else {
+            obs_frontend_recording_pause(true);
+        }
+    });
+
     // https://github.com/obsproject/obs-studio/pull/12580
     /* Update release version number and uncomment when related request is merged.
 


### PR DESCRIPTION
My usual config for OBS has different buttons for starting and stopping recording, but I pause using a single button. The plugin so far did not allow that, hence this pull request. I wasn't able to test it though, since I don't know how to test it.